### PR TITLE
Update message presentation of clipboard content to be consistent with braille settings

### DIFF
--- a/src/orca/plugins/Clipboard/Clipboard.py
+++ b/src/orca/plugins/Clipboard/Clipboard.py
@@ -29,7 +29,7 @@ class Clipboard(GObject.Object, Peas.Activatable):
     def speakClipboard(self, script, inputEvent):
         API = self.object
         Message = self.getClipboard()
-        API.app.getAPIHelper().outputMessage(Message)
+        API.app.getAPI('OrcaState').activeScript.presentMessage(Message, resetStyles=False)
     def getClipboard(self):
         Message = ""
         FoundClipboardContent = False


### PR DESCRIPTION
For now, the clipboard content announcement stays persistent in braille even if user configured a delay for braille message.
This PR allows clipboard announcement plugin to be consistent with user setting.

I tried to do the same for self-voicing or to add the ability to pass a flag to select the desired behavior (force persistence or not) but I still have to learn how it works to do so.
