### PR TITLE
Fix return statement

### DIFF
--- a/src/orca/plugin_system_manager.py
+++ b/src/orca/plugin_system_manager.py
@@ -260,7 +260,7 @@ class APIHelper():
                 key = shortcutElementLower
         if clickCount == 0:
             clickCount = 1
-        return .registerShortcut(function, key, name, clickCount, orcaKey, shiftKey, ctrlKey, altKey, learnModeEnabled)
+        return selv.registerShortcut(function, key, name, clickCount, orcaKey, shiftKey, ctrlKey, altKey, learnModeEnabled)
 
     def registerShortcut(self, function, key, name, clickCount = 1, orcaKey = True, shiftKey = False, ctrlKey = False, altKey = False, learnModeEnabled = True):
         keybindings = self.app.getDynamicApiManager().getAPI('Keybindings')


### PR DESCRIPTION
self was missing before the dot character on return, which make orca crash on startup with this eror:
```txt
Traceback (most recent call last):
  File "/usr/local/bin/orca", line 283, in <module>
    sys.exit(main())
  File "/usr/local/bin/orca", line 253, in main
    from orca import orca
  File "/usr/local/lib/python3.7/site-packages/orca/orca.py", line 84, in <module>
    from orca import plugin_system_manager
  File "/usr/local/lib/python3.7/site-packages/orca/plugin_system_manager.py", line 263
    return .registerShortcut(function, key, name, clickCount, orcaKey, shiftKey, ctrlKey, altKey, learnModeEnabled)
           ^
SyntaxError: invalid syntax
```
